### PR TITLE
Update index.html (remove ai shortcut)

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -49,6 +49,7 @@
       <a class="quicklink" onclick="hire('https://discord.gg')"><img class='shortcut' src="/img/shortcuts/dc.webp"></a>
       <a class="quicklink" onclick="hire('https://www.espn.com/watch/')"><img class='shortcut'
           src="/img/shortcuts/ESPN.webp"></a>
+      <a class="quicklink" onclick="hire('https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=1')><img class='shortcut' src="/img/shortcuts/freegpt.webp"></a>
       <a class="quicklink" onclick="hire('https://github.com')"><img class='shortcut'
           src="/img/shortcuts/GitHub.webp"></a>
       <a class="quicklink" onclick="hire('https://google.com')"><img class='shortcut'


### PR DESCRIPTION
I am a 55gms fan and I noticed that the ai shortcut is leading to the 404 page. I wanted to make myself useful so I am making this pull request to delete the shortcut/warn you of the error.